### PR TITLE
Support goweb v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mapfunc/mapfunc
+rest/rest

--- a/diary/api/api.go
+++ b/diary/api/api.go
@@ -1,9 +1,9 @@
 package api
 
 import (
+	"./article"
 	"labix.org/v2/mgo"
 	"log"
-	"./article"
 )
 
 func Init(db *mgo.Database) {

--- a/diary/api/article/article.go
+++ b/diary/api/article/article.go
@@ -1,7 +1,7 @@
 package article
 
 import (
-	"github.com/stretchrcom/goweb/goweb"
+	"github.com/stretchr/goweb"
 	"labix.org/v2/mgo"
 	"log"
 )
@@ -11,5 +11,5 @@ const COLLECTION = "article"
 func Init(db *mgo.Database) {
 	log.Println("Initializing article package")
 	controller := NewController(db)
-	goweb.MapRest("/articles", controller)
+	goweb.MapController("/articles", controller)
 }

--- a/diary/main.go
+++ b/diary/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"./api"
 	"flag"
-	"github.com/stretchrcom/goweb/goweb"
+	"github.com/stretchr/goweb"
 	"labix.org/v2/mgo"
 	"log"
 	"net/http"
@@ -37,8 +37,7 @@ func main() {
 
 	log.Println("Initializing handlers...")
 	api.Init(db)
-	goweb.ConfigureDefaultFormatters()
-	http.Handle("/api/", http.StripPrefix("/api", goweb.DefaultHttpHandler))
+	http.Handle("/api/", http.StripPrefix("/api", goweb.DefaultHttpHandler()))
 	log.Println("Registered a handler for RESTful API.")
 
 	http.Handle("/", http.FileServer(http.Dir("static")))

--- a/diary/static/js/controllers.js
+++ b/diary/static/js/controllers.js
@@ -3,7 +3,7 @@ function ArticleListCntl($scope, $routeParams, $location, Article) {
 	// Get articles
 	$scope.articles = [];
 	Article.get({}, function(r) {
-		$scope.articles = _.map(r.D, function(d) {
+		$scope.articles = _.map(r.d, function(d) {
 			return new Article(d);
 		});
 	});
@@ -34,7 +34,7 @@ function ArticleListCntl($scope, $routeParams, $location, Article) {
 		});
 
 		article.$save(function(d){
-			article._id = d.D._id;
+			article._id = d.d._id;
 			$scope.articles.push(article)
 		});
 	};

--- a/mapfunc/main.go
+++ b/mapfunc/main.go
@@ -2,17 +2,19 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchrcom/goweb/goweb"
+	"github.com/stretchr/goweb"
+	"github.com/stretchr/goweb/context"
+	"net/http"
 )
 
 func main() {
-
-	handler := func(c *goweb.Context) {
-		name := c.PathParams["name"]
-		animal := c.PathParams["animal"]
-		fmt.Fprintf(c.ResponseWriter, "Hey %s, your favorite animal is a %s", name, animal)
+	handler := func(c context.Context) error {
+		name := c.PathParams().Get("name")
+		animal := c.PathParams().Get("animal")
+		body := fmt.Sprintf("Hey %s, your favorite animal is a %s", name, animal)
+		return goweb.Respond.With(c, http.StatusOK, []byte(body))
 	}
 
-	goweb.MapFunc("/people/{name}/animals/{animal}", handler)
-	goweb.ListenAndServe(":8080")
+	goweb.Map("/people/{name}/animals/{animal}", handler)
+	http.ListenAndServe(":8080", goweb.DefaultHttpHandler())
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -2,41 +2,50 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchrcom/goweb/goweb"
+	"github.com/stretchr/goweb"
+	"github.com/stretchr/goweb/context"
+	"net/http"
 )
 
 type MyController struct{}
 
-func (cr *MyController) Create(cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Create resource")
+func (cr *MyController) Create(cx context.Context) error {
+	body := "Create resource"
+	return goweb.Respond.With(cx, http.StatusCreated, []byte(body))
 }
 
-func (cr *MyController) Read(id string, cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Read resource %s", id)
+func (cr *MyController) Read(id string, cx context.Context) error {
+	body := fmt.Sprintf("Read resource %s", id)
+	return goweb.Respond.With(cx, http.StatusOK, []byte(body))
 }
 
-func (cr *MyController) ReadMany(cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Read many resources")
+func (cr *MyController) ReadMany(cx context.Context) error {
+	body := "Read many resources"
+	return goweb.Respond.With(cx, http.StatusOK, []byte(body))
 }
 
-func (cr *MyController) Update(id string, cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Update resource %s", id)
+func (cr *MyController) Update(id string, cx context.Context) error {
+	body := fmt.Sprintf("Update resource %s", id)
+	return goweb.Respond.With(cx, http.StatusOK, []byte(body))
 }
 
-func (cr *MyController) UpdateMany(cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Update many resources")
+func (cr *MyController) UpdateMany(cx context.Context) error {
+	body := "Update many resources"
+	return goweb.Respond.With(cx, http.StatusOK, []byte(body))
 }
 
-func (cr *MyController) Delete(id string, cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Delete resource %s", id)
+func (cr *MyController) Delete(id string, cx context.Context) error {
+	body := fmt.Sprintf("Delete resource %s", id)
+	return goweb.Respond.With(cx, http.StatusOK, []byte(body))
 }
 
-func (cr *MyController) DeleteMany(cx *goweb.Context) {
-	fmt.Fprintf(cx.ResponseWriter, "Delete many resources")
+func (cr *MyController) DeleteMany(cx context.Context) error {
+	body := "Delete many resources"
+	return goweb.Respond.With(cx, http.StatusOK, []byte(body))
 }
 
 func main() {
 	controller := new(MyController)
-	goweb.MapRest("/api", controller)
-	goweb.ListenAndServe(":8080")
+	goweb.MapController("/api", controller)
+	http.ListenAndServe(":8080", goweb.DefaultHttpHandler())
 }


### PR DESCRIPTION
goweb が2ヶ月前に v2 になったことにより
sample がそのまま動かない所とかあったので修正してみました。
## 主な変更点
1. リポジトリ
   
   ``` diff
   - github.com/stretchrcom/goweb/goweb
   + github.com/stretchr/goweb
   ```
2. Deprecated の修正
   - `MapFunc()` → `Map()`
   - `MapRest()` → `MapController()`
3. context の変更とそれに伴う各種 Respond 関数の変更
## ちょっとできなかったところ

`/diary/api/article/controller.go` で `Update()` → `Replace()` にしたのですが、
これは diary の画面で article 開いたあとの save ボタンが PUT ではなく POST で呼ばれるため、
`Update(id)` が呼ばれずに保存されなかったのでその対処としました。(POST なら Replace、PUT なら Update)

本来であれば Update のままでいたかったのですが、save ボタン押した時に HTTP メソッドを PUT に
変更する方法がわからなかったので、とりあえず……
